### PR TITLE
`dist_uncert` geographic center calculation and bug fixes

### DIFF
--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -347,8 +347,7 @@
     ```julia
     haversine(lat₁, lon₁, lat₂, lon₂)
     ```
-    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and 
-    (lat₂, lon₂).
+    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and (lat₂, lon₂).
 
     """
     function haversine(lat₁, lon₁, lat₂, lon₂)
@@ -358,15 +357,19 @@
     end
     export haversine
 
-## --- Calculate maximum arc-degree distance between a series of points
+## --- Calculate center of, and maximum arc-degree distance between, a series of points
     """
     ```julia
     dist_uncert(lats, lons)    
     ```
 
-    Find the distance uncertainty (in arc degrees) given a list of decimal degree 
-    points `lats` and `lons`. Returns 1/2 of the distance between the farthest
-    two points.
+    Find the decimal degree center and associated distance uncertainty (in arc degrees) given a list of decimal 
+    degree points `lats` and `lons`. Returns 1/2 of the distance between the farthest two points.
+
+    ### Examples
+    ```julia
+    (lat, lon, uncert) = dist_uncert(lats, lons)    
+    ```
 
     """
     function dist_uncert(lats, lons)
@@ -380,6 +383,6 @@
         end
         return maxdist/2
     end
-    export dist_uncert
+    export nanmean(lats), nanmean(lons), dist_uncert
 
 ## --- End of File

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -363,8 +363,8 @@
     dist_uncert(lats, lons)    
     ```
 
-    Find the decimal degree center and associated distance uncertainty (in arc degrees) given a list of decimal degree points 
-    `lats` and `lons`. Returns latitude and longitude of the center, and 1/2 of the distance between the farthest two points.
+    Find the decimal degree center and associated distance uncertainty (in arc degrees) from lists `lats` and `lons` of decimal 
+    degree coordinates. Returns latitude and longitude of the center, and 1/2 of the distance between the farthest two points.
 
     """
     function dist_uncert(lats, lons)
@@ -372,8 +372,8 @@
         maxdist = zero(float(eltype(lats)))
         for i in eachindex(lats)
             for j in 1+firstindex(lats):lastindex(lats)
-                # If a point is compared to itself, distance is 0
-                if i !=j
+                # If a point is compared to itself, distance is 0; comparison is susceptible to roundoff error
+                if i != j
                     dist = haversine(lats[i], lons[i], lats[j], lons[j])
                     dist > maxdist && (maxdist = dist)
                 end

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -347,8 +347,7 @@
     ```julia
     haversine(lat₁, lon₁, lat₂, lon₂)
     ```
-    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and 
-    (lat₂, lon₂).
+    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and (lat₂, lon₂).
 
     """
     function haversine(lat₁, lon₁, lat₂, lon₂)
@@ -364,9 +363,8 @@
     dist_uncert(lats, lons)    
     ```
 
-    Find the distance uncertainty (in arc degrees) given a list of decimal degree 
-    points `lats` and `lons`. Returns 1/2 of the distance between the farthest
-    two points.
+    Find the decimal degree center and associated distance uncertainty (in arc degrees) given a list of decimal degree points 
+    `lats` and `lons`. Returns latitude and longitude of the center, and 1/2 of the distance between the farthest two points.
 
     """
     function dist_uncert(lats, lons)
@@ -378,7 +376,7 @@
                 dist > maxdist && (maxdist = dist)
             end
         end
-        return maxdist/2
+        return (nanmaximum(lats)+nanminimum(lats))/2, (nanmaximum(lons)+nanminimum(lons))/2, maxdist/2
     end
     export dist_uncert
 

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -370,10 +370,10 @@
 
     """
     function dist_uncert(lats, lons)
-        @assert eachindex(lats) == eachindex(lons) == 1:length(lats)
+        @assert eachindex(lats) == eachindex(lons)
         maxdist = zero(float(eltype(lats)))
-        for i in 1:lastindex(lats)
-            for j in 2:lastindex(lats)
+        for i in eachindex(lats)
+            for j in 1+firstindex(lats):lastindex(lats)
                 dist = haversine(lats[i], lons[i], lats[j], lons[j])
                 dist > maxdist && (maxdist = dist)
             end

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -372,8 +372,11 @@
         maxdist = zero(float(eltype(lats)))
         for i in eachindex(lats)
             for j in 1+firstindex(lats):lastindex(lats)
-                dist = haversine(lats[i], lons[i], lats[j], lons[j])
-                dist > maxdist && (maxdist = dist)
+                # If a point is compared to itself, distance is 0
+                if i !=j
+                    dist = haversine(lats[i], lons[i], lats[j], lons[j])
+                    dist > maxdist && (maxdist = dist)
+                end
             end
         end
         return (nanmaximum(lats)+nanminimum(lats))/2, (nanmaximum(lons)+nanminimum(lons))/2, maxdist/2

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -347,7 +347,8 @@
     ```julia
     haversine(lat₁, lon₁, lat₂, lon₂)
     ```
-    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and (lat₂, lon₂).
+    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and 
+    (lat₂, lon₂).
 
     """
     function haversine(lat₁, lon₁, lat₂, lon₂)
@@ -363,9 +364,13 @@
     dist_uncert(lats, lons)    
     ```
 
-    Find the decimal degree center and associated distance uncertainty (in arc degrees) from lists `lats` and `lons` of decimal 
-    degree coordinates. Returns latitude and longitude of the center, and 1/2 of the distance between the farthest two points.
+    Find the decimal degree center and associated uncertainty (in arc degrees) from 
+    lists `lats` and `lons` of decimal degree coordinates. 
 
+    ### Examples
+    ```julia
+    (lat_ctr, lon_ctr, uncertainty) = dist_uncert(lats, lons)
+    ```
     """
     function dist_uncert(lats, lons)
         @assert eachindex(lats) == eachindex(lons)

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -342,4 +342,44 @@
     end
     export randlatlon
 
+## --- Calculate distance uncertainty in arc degrees
+    """
+    ```julia
+    haversine(lat₁, lon₁, lat₂, lon₂)
+    ```
+    Calculate the arc degree distance between two decimal degree points (lat₁, lon₁) and 
+    (lat₂, lon₂).
+
+    """
+    function haversine(lat₁, lon₁, lat₂, lon₂)
+        lat₁ᵣ, lon₁ᵣ, lat₂ᵣ, lon₂ᵣ = (lat₁, lon₁, lat₂, lon₂) .* (pi/180)
+        dist = acos(sin(lat₁ᵣ) * sin(lat₂ᵣ) + cos(lat₁ᵣ) * cos(lat₂ᵣ) * cos(lon₁ᵣ - lon₂ᵣ))
+        return dist * 180/pi
+    end
+    export haversine
+
+## --- Calculate maximum arc-degree distance between a series of points
+    """
+    ```julia
+    dist_uncert(lats, lons)    
+    ```
+
+    Find the distance uncertainty (in arc degrees) given a list of decimal degree 
+    points `lats` and `lons`. Returns 1/2 of the distance between the farthest
+    two points.
+
+    """
+    function dist_uncert(lats, lons)
+        @assert eachindex(lats) == eachindex(lons) == 1:length(lats)
+        maxdist = zero(float(eltype(lats)))
+        for i in 1:lastindex(lats)
+            for j in 2:lastindex(lats)
+                dist = haversine(lats[i], lons[i], lats[j], lons[j])
+                dist > maxdist && (maxdist = dist)
+            end
+        end
+        return maxdist/2
+    end
+    export dist_uncert
+
 ## --- End of File

--- a/src/utilities/GIS.jl
+++ b/src/utilities/GIS.jl
@@ -397,8 +397,9 @@
     ```
     Return the centroid of a set of latitudes and longitudes on a sphere
     """
-    function centroid(lats::AbstractArray{T}, lons::AbstractArray{T}) where {T}
-        x, y, z = similar(lats), similar(lats), similar(lats)
+    function centroid(lats::AbstractArray{T1}, lons::AbstractArray{T2}) where {T1,T2}
+        T = float(promote_type(T1, T2))
+        x, y, z = similar(lats, T), similar(lats, T), similar(lats, T)
         @inbounds for i in eachindex(lats, lons)
             φ = deg2rad(90 - lats[i])
             θ = deg2rad(lons[i])
@@ -415,9 +416,9 @@
 
     """
     ```julia
-    x, y, z = cartesian(ρ, θ, φ)
+    x, y, z = cartesian(ρ, φ, θ)
     ```
-    Convert from coordinates (`ρ`,`θ`,`φ`) to cartesian coordinates (`x`,`y`,`z`).
+    Convert from coordinates (`ρ`,`φ`,`θ`) to cartesian coordinates (`x`,`y`,`z`).
     """
     function cartesian(ρ::Number, φ::Number, θ::Number)
         x = ρ * sin(φ) * cos(θ)
@@ -430,7 +431,7 @@
     ```julia
     ρ, θ, φ = cartesian(x, y, z))
     ```
-    Convert from cartesian coordinates (`x`,`y`,`z`) to spherical coordinates (`ρ`,`θ`,`φ`).
+    Convert from cartesian coordinates (`x`,`y`,`z`) to spherical coordinates (`ρ`,`φ`,`θ`).
     """
     function spherical(x::Number, y::Number, z::Number)
         ρ = sqrt(x^2 + y^2 + z^2)

--- a/test/testUtilities.jl
+++ b/test/testUtilities.jl
@@ -68,13 +68,14 @@
     @test isapprox(haversine(90, 2, 0, 0), 90)
     @test isapprox(haversine(0, 0, 90, 2), 90)
 
+    # Centroid of a set of lats and lons on a sphere
+    lats, lons = [-1, 1, 0, 0.], [0, 0, -1, 1.]
+    @test all(StatGeochem.centroid(lats, lons) .≈ (0.0, 0.0))
 
-    # Find the maximum arc-degree distance between a list of points
-    lats = [0, 0, 0, 0]
-    lons = [0, 30, 23, 90]
-    @test isapprox(dist_uncert(lats, lons)[1], 0)
-    @test isapprox(dist_uncert(lats, lons)[2], 45)
-    @test isapprox(dist_uncert(lats, lons)[3], 45)
+    # Maximum arc-degree distance between a list of points on a sphere
+    @test all(dist_uncert(lats, lons) .≈ (0.0, 0.0, 1.0))
+    lats, lons = [0, 0, 0, 0], [0, 30, 23, 90]
+    @test all(dist_uncert(lats, lons) .≈ (0.0, 34.15788270532762, 45.0))
 
 
 ## --- Etc.jl

--- a/test/testUtilities.jl
+++ b/test/testUtilities.jl
@@ -58,20 +58,20 @@
 
 
     # Calculate arc-degree distance
-    isapprox(haversine(1, 0, 0, 0), 1)
-    isapprox(haversine(0, 1, 0, 0), 1)
-    isapprox(haversine(0, 0, 1, 0), 1)
-    isapprox(haversine(0, 0, 0, 1), 1)
-    isapprox(haversine(0, 0, 0, 0), 0)
+    @test isapprox(haversine(1, 0, 0, 0), 1)
+    @test isapprox(haversine(0, 1, 0, 0), 1)
+    @test isapprox(haversine(0, 0, 1, 0), 1)
+    @test isapprox(haversine(0, 0, 0, 1), 1)
+    @test isapprox(haversine(0, 0, 0, 0), 0)
 
-    isapprox(haversine(90, 2, 0, 0), 90)
-    isapprox(haversine(0, 0, 90, 2), 90)
+    @test isapprox(haversine(90, 2, 0, 0), 90)
+    @test isapprox(haversine(0, 0, 90, 2), 90)
 
 
     # Find the maximum arc-degree distance between a list of points
     lats = [0, 0, 0, 0]
     lons = [0, 30, 23, 90]
-    isapprox(dist_uncert(lats, lons), 45)
+    @test isapprox(dist_uncert(lats, lons), 45)
 
 
 ## --- Etc.jl

--- a/test/testUtilities.jl
+++ b/test/testUtilities.jl
@@ -47,6 +47,7 @@
     @test data == [-9999 -9999 5 2; -9999 20 100 36; 3 8 35 10; 32 42 50 6; 88 75 27 9; 13 5 1 -9999]
     @test metadata["nodata"] == -9999
 
+
     # Random lat-lon generation
     @test isa(randlatlon(), Tuple{Float64,Float64})
     lat,lon = randlatlon(100)
@@ -54,6 +55,24 @@
     @test minimum(lat) >= -90
     @test maximum(lon) <= 180
     @test minimum(lon) >= -180
+
+
+    # Calculate arc-degree distance
+    isapprox(haversine(1, 0, 0, 0), 1)
+    isapprox(haversine(0, 1, 0, 0), 1)
+    isapprox(haversine(0, 0, 1, 0), 1)
+    isapprox(haversine(0, 0, 0, 1), 1)
+    isapprox(haversine(0, 0, 0, 0), 0)
+
+    isapprox(haversine(90, 2, 0, 0), 90)
+    isapprox(haversine(0, 0, 90, 2), 90)
+
+
+    # Find the maximum arc-degree distance between a list of points
+    lats = [0, 0, 0, 0]
+    lons = [0, 30, 23, 90]
+    isapprox(dist_uncert(lats, lons), 45)
+
 
 ## --- Etc.jl
 

--- a/test/testUtilities.jl
+++ b/test/testUtilities.jl
@@ -72,7 +72,9 @@
     # Find the maximum arc-degree distance between a list of points
     lats = [0, 0, 0, 0]
     lons = [0, 30, 23, 90]
-    @test isapprox(dist_uncert(lats, lons), 45)
+    @test isapprox(dist_uncert(lats, lons)[1], 0)
+    @test isapprox(dist_uncert(lats, lons)[2], 45)
+    @test isapprox(dist_uncert(lats, lons)[3], 45)
 
 
 ## --- Etc.jl


### PR DESCRIPTION
`dist_uncert` now returns the latitude and longitude of the geographic center of the points it is passed. Update tests accordingly.

Fixed a bug in `dist_uncert` where calculating the distance of a point with itself would occasionally result in an `acos` domain error when the points were passed to `haversine`.

Minor changes to docstring wording.