### PR TITLE
Fix perplex_query_modes issue with "Missing data" value

### DIFF
--- a/src/utilities/Geochemistry.jl
+++ b/src/utilities/Geochemistry.jl
@@ -1433,6 +1433,10 @@
         system("sed -e \"s/^  *//\" -e \"s/  *\$//\" -i.backup $(prefix)$(index)_1.phm")
         # Merge delimiters
         system("sed -e \"s/  */ /g\" -i.backup $(prefix)$(index)_1.phm")
+        # Replace "Missing data" with just "Missing" 
+        file_content = read("$prefix$index_1.phm", String)
+        modified_content = replace(file_content, "Missing data" => replace("Missing data", "Missing data" => "Missing"))
+        write("$prefix$index_1.phm", modified_content)
 
         # Read results and return them if possible
         result = importas==:Dict ? Dict() : ()

--- a/src/utilities/Geochemistry.jl
+++ b/src/utilities/Geochemistry.jl
@@ -1434,9 +1434,9 @@
         # Merge delimiters
         system("sed -e \"s/  */ /g\" -i.backup $(prefix)$(index)_1.phm")
         # Replace "Missing data" with just "Missing" 
-        file_content = read("$prefix$index_1.phm", String)
+        file_content = read("$(prefix)$(index)_1.phm", String)
         modified_content = replace(file_content, "Missing data" => replace("Missing data", "Missing data" => "Missing"))
-        write("$prefix$index_1.phm", modified_content)
+        write("$(prefix)$(index)_1.phm", modified_content)
 
         # Read results and return them if possible
         result = importas==:Dict ? Dict() : ()

--- a/src/utilities/Project.toml
+++ b/src/utilities/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+StatGeochem = "df4de05a-b714-11e8-3c2a-c30fb13e804c"


### PR DESCRIPTION
Since all values in the .phm file for query_modes are space delimited, the "Missing data" value was offsetting all columns in those rows. This PR replaces "Missing data" with "Missing" to fix that issue. 