### PR TITLE
Add T computation for Ti and Zr in Rutile and zircon, from Ferry and Watson, 2007

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.swp
+*.vscode
 
 # Other languages
 *.c

--- a/src/utilities/Geochemistry.jl
+++ b/src/utilities/Geochemistry.jl
@@ -2613,6 +2613,20 @@
 
     """
     ```julia
+    TC = Ferry_Ti_in_zirconT(TC::Number, aSiO2::Number, aTiO2::Number)
+    ```
+    Calculate zircon temperature saturation in degrees Celcius
+    Ti is parts per million by weight of titanium in zircon,
+    `aSiO2` silica activity and `aTiO2` titanium activity, following
+    the equations of Ferry and Watson, 2007.
+    (doi: 10.1007/s00410-007-0201-0)
+    """
+    function Ferry_Ti_in_zirconT(Ti::Number, aSiO2::Number, aTiO2::Number)
+        1 / ((5.711) - log10(aSiO2) + log10(aTiO2) - log10(Ti)) * (4800.0) .- 273.15
+    end
+
+    """
+    ```julia
     Ti = Crisp_Ti_in_zircon(TC::Number, Pbar::Number, aSiO2::Number, aTiO2::Number)
     ```
     Parts per million by weight of titanium in zircon at temperature `TC` degrees
@@ -2627,7 +2641,6 @@
         exp10(5.84 - 4800.0/T - 0.12*P - 0.0056*P^3 - log10(aSiO2)*f +log10(aTiO2)) / f
     end
 
-
     """
     ```julia
     Ti = Ferry_Zr_in_rutile(TC::Number, aSiO2::Number)
@@ -2640,5 +2653,20 @@
     function Ferry_Zr_in_rutile(TC::Number, aSiO2::Number)
         exp10(7.420 - 4530.0/(TC+273.15) - log10(aSiO2))
     end
+
+    # calculate the temperature of rutile saturation in degrees Celsius
+    """
+    ```julia
+    TC = Ferry_Zr_in_rutileT(Ti::Number, aSiO2::Number)
+    ```
+    Calculate rutile temperature saturation in degrees Celcius
+    Ti is parts per million by weight of zirconium in rutile,
+    `aSiO2` silica activity, following the equations of Ferry and Watson, 2007.
+    (doi: 10.1007/s00410-007-0201-0)
+    """
+    function Ferry_Zr_in_rutileT(Ti::Number, aSiO2::Number)
+        1 / ((7.420) - log10(aSiO2) - log10(Ti)) * (4530.0) .- 273.15
+    end
+
 
 ## --- End of File

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,19 +1,21 @@
 using StatGeochem
 using Test, Statistics, StatsBase, Downloads
 
-# Utilities
-@testset "Import" begin include("testImport.jl") end
-@testset "Resampling" begin include("testResampling.jl") end
-@testset "Changepoint" begin include("testChangepoint.jl") end
-@testset "Geochemistry" begin include("testGeochemistry.jl") end
+@testset "All tests" begin
+    # Utilities
+    @testset "Import" begin include("testImport.jl") end
+    @testset "Resampling" begin include("testResampling.jl") end
+    @testset "Changepoint" begin include("testChangepoint.jl") end
+    @testset "Geochemistry" begin include("testGeochemistry.jl") end
 
-using FileIO
-@testset "Other Utilities" begin include("testUtilities.jl") end
+    using FileIO
+    @testset "Other Utilities" begin include("testUtilities.jl") end
 
-# Resources
-@testset "Crust 1.0" begin include("testCrust1.jl") end
-@testset "Litho 1.0" begin include("testLitho1.jl") end
-@testset "Other Resources" begin include("testResources.jl") end
+    # Resources
+    @testset "Crust 1.0" begin include("testCrust1.jl") end
+    @testset "Litho 1.0" begin include("testLitho1.jl") end
+    @testset "Other Resources" begin include("testResources.jl") end
 
-using Plots
-@testset "Package Extensions" begin include("testExtensions.jl") end
+    using Plots
+    @testset "Package Extensions" begin include("testExtensions.jl") end
+end

--- a/test/testGeochemistry.jl
+++ b/test/testGeochemistry.jl
@@ -130,7 +130,9 @@
 ## -- Test thermometers
 
     @test StatGeochem.Ferry_Zr_in_rutile(750,1) ≈ 982.8714076786658
+    @test StatGeochem.Ferry_Zr_in_rutileT(982.8714076786658,1) ≈ 750.0
     @test StatGeochem.Ferry_Ti_in_zircon(750,1,1) ≈ 10.46178465494583
+    @test StatGeochem.Ferry_Ti_in_zirconT(10.46178465494583, 1, 1) ≈ 750.0
 
     @test StatGeochem.Crisp_Ti_in_zircon(750,0,1,1) ≈ 14.08608953046849
     @test StatGeochem.Crisp_Ti_in_zircon(750,1000,1,1) ≈ 13.703165806686624


### PR DESCRIPTION
Hi, 

I needed this so I've implemented the functions that gives temperature from Zr and Ti in zircon and rutile (only the ones giving Ti and Zr were implemented before). 
Tests were also added. 

Just a more general question, is there a reason why the package Measurements.jl is not used in this package? I think it would be a nice feature to have uncertainty propagated from this kind of functions. 

I was thinking about something like that to not break anything:

```
function Ferry_Ti_in_zirconT(Ti::Number, aSiO2::Number, aTiO2::Number; uncertainty=false)
    if uncertainty
        1 / ((5.711±0.072) - log10(aSiO2) + log10(aTiO2) - log10(Ti)) * (4800.0±86) .- 273.15
    else
        1 / ((5.711) - log10(aSiO2) + log10(aTiO2) - log10(Ti)) * (4800.0) .- 273.15
    end
end
```

What do you think?

Also, I have local tests failure unrelated to this PR due to the test of Perplex on line 245 of testGeochemistry.jl (I am on Mac). That would probably be fixed by using the Perple_X_jll at some point.

Cheers,